### PR TITLE
Replace aria-pressed attribute from menu toggle buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       <!-- Gets fixed by JS at wide widths -->
       <div class="site-header__fixable fixable">
         <div class="header__left">
-          <button class="nav-primary__button" aria-controls="site-header__inner" aria-label="Toggle navigation">
+          <button class="nav-primary__button" aria-controls="site-header__inner" aria-label="Toggle navigation" aria-expanded="false">
             <span class="nav-primary__icon"></span>
           </button>
         </div>

--- a/src/css/components/header.css
+++ b/src/css/components/header.css
@@ -40,7 +40,7 @@
     box-shadow: -36px 1px 36px rgba(0, 0, 0, 0.08);
   }
 
-  .site-header__fixable.js-fixed &:not([aria-expanded="true"]) {
+  .site-header__fixable.js-fixed &:not([data-menu-open="true"]) {
     transform: translatex(-101%);
     opacity: 0;
   }
@@ -133,7 +133,7 @@
     grid-column: 5 / 14;
   }
 
-  &[aria-expanded="true"] {
+  &[data-menu-open="true"] {
     visibility: visible;
     transform: translatex(0);
   }

--- a/src/css/components/nav-button-mobile.css
+++ b/src/css/components/nav-button-mobile.css
@@ -75,7 +75,7 @@
     transition: all 0.2s;
   }
 
-  .mobile-nav-button[aria-pressed="true"] & {
+  .mobile-nav-button[aria-expanded="true"] & {
     background-color: transparent;
 
     &:before {

--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -8,18 +8,24 @@
   const body = document.querySelector('body');
   const overlay = document.querySelector('.overlay');
 
+  const focusableNavElements = mobileNavWrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+  const firstFocusableEl = focusableNavElements[0];
+  const lastFocusableEl = focusableNavElements[focusableNavElements.length - 1];
+
   function init() {
     mobileNavButton.setAttribute('aria-controls', mobileNavWrapperId);
+    mobileNavWrapper.setAttribute('data-menu-open', "false");
+    mobileNavButton.setAttribute('aria-expanded', "false");
   }
 
   function isMobileNavOpen() {
-    return mobileNavWrapper.getAttribute('aria-expanded') === 'true';
+    return mobileNavWrapper.getAttribute('data-menu-open') === 'true';
   }
 
   function toggleMobileNav(state) {
     const value = state ? 'true' : 'false';
-    mobileNavWrapper.setAttribute('aria-expanded', value);
-    mobileNavButton.setAttribute('aria-pressed', value);
+    mobileNavWrapper.setAttribute('data-menu-open', value);
+    mobileNavButton.setAttribute('aria-expanded', value);
 
     // Overlay
     if (state) {
@@ -50,5 +56,22 @@
 
   overlay.addEventListener('touchstart', () => {
     toggleMobileNav(false);
+  });
+
+  // Focus trap.
+  mobileNavWrapper.addEventListener('keydown', function(e) {
+    if (e.key === 'Tab' || e.keyCode === 9) {
+      if ( e.shiftKey ) /* shift + tab */ {
+        if (document.activeElement === firstFocusableEl) {
+          mobileNavButton.focus();
+          e.preventDefault();
+        }
+      } else /* tab */ {
+        if (document.activeElement === lastFocusableEl) {
+          mobileNavButton.focus();
+          e.preventDefault();
+        }
+      }
+    }
   });
 })()

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -51,7 +51,7 @@
     const siteHeaderToggleElement = document.querySelector('.site-header__inner');
 
     function wideNavIsOpen() {
-      return wideNavButton.getAttribute('aria-pressed') === 'true';
+      return wideNavButton.getAttribute('aria-expanded') === 'true';
     }
 
     wideNavButton.addEventListener('click', () => {
@@ -65,16 +65,16 @@
 
     function showWideNav() {
       if (isDesktopNav()) {
-        wideNavButton.setAttribute('aria-pressed', 'true');
-        siteHeaderToggleElement.setAttribute('aria-expanded', 'true');
+        wideNavButton.setAttribute('aria-expanded', 'true');
+        siteHeaderToggleElement.setAttribute('data-menu-open', 'true');
       }
     }
 
     // Resets the wide nav button to be closed (it's default state).
     function hideWideNav() {
       if (isDesktopNav()) {
-        wideNavButton.setAttribute('aria-pressed', 'false');
-        siteHeaderToggleElement.setAttribute('aria-expanded', 'false');
+        wideNavButton.setAttribute('aria-expanded', 'false');
+        siteHeaderToggleElement.setAttribute('data-menu-open', 'false');
       }
     }
 


### PR DESCRIPTION
For both mobile and desktop menu toggle buttons, change `aria-pressed` to `aria-expanded`

* Ensure `aria-expanded` attribute set on page load
* Remove `aria-expanded` from header/menu wrapper as not correct, replace with with `data-menu-open` attribute to keep existing styling/behaviour
* Add focus trap for mobile menu to prevent tabbing throughout the page.