### PR TITLE
3091875: fixing primary nav items wrap text as per proof of concept.

### DIFF
--- a/src/css/components/header.css
+++ b/src/css/components/header.css
@@ -131,7 +131,7 @@
   }
 
   @media (--lg) {
-    grid-column: 5 / 14;
+    grid-column: 4 / 14;
   }
 
   &[data-menu-open="true"] {

--- a/src/css/components/nav-primary.css
+++ b/src/css/components/nav-primary.css
@@ -43,6 +43,12 @@
       letter-spacing: 0.02em;
     }
   }
+
+  @media (--nav) {
+    max-width: 500px;
+    overflow: hidden;
+    overflow-x: auto;
+  }
 }
 
 .primary-nav--level-1 {
@@ -60,7 +66,13 @@
       margin: 0;
 
       &:not(:last-child) {
-        margin-right: var(--sp2);
+        margin-right: var(--sp1-5);
+      }
+      
+      @media (--xl) {
+        &:not(:last-child) {
+          margin-right: var(--sp2);
+        }
       }
 
       &:hover {
@@ -102,6 +114,7 @@
         display: inline-flex;
         align-items: center;
         padding: var(--sp2) 0;
+        white-space: nowrap;
 
         &:after {
           content: '';


### PR DESCRIPTION
- This PR fixes wrap the word for primary navigation 1st level menu links.
- Also as per Figma designs, medium device resolution has 27px of margin-right. So updated according to the design value.
- To reduce space between logo and navigation, the grid column used as 4 /1 4 instead of 5 / 14.
