### PR TITLE
WIP: 13476291: Create CSS body class that enables mobile menu at all widths

### DIFF
--- a/src/css/components/header-buttons-mobile.css
+++ b/src/css/components/header-buttons-mobile.css
@@ -16,3 +16,11 @@
     display: none;
   }
 }
+
+.mobile-nav {
+  @media (--nav) { /* Should this wrap the entire mobile class? */
+    .mobile-buttons {
+      display: flex;
+    }
+  }
+}

--- a/src/css/components/header-search-narrow.css
+++ b/src/css/components/header-search-narrow.css
@@ -68,3 +68,12 @@
   width: var(--sp3);
   cursor: pointer;
 }
+
+.mobile-nav {
+  @media (--nav) {
+    .search-narrow__wrapper {
+      display: block;
+      width: 100%;
+    }
+  }
+}

--- a/src/css/components/header.css
+++ b/src/css/components/header.css
@@ -197,6 +197,17 @@
       /* Possibly redundant */
       padding: 0 var(--sp3) var(--sp3);
       border-top-width: var(--sp7);
+
+      &[data-menu-open="true"] {
+        visibility: visible;
+        transform: translatex(0);
+      }
+
+      /* Temporary brute force */
+      .primary-nav,
+      .secondary-nav__wrapper {
+        display: none;
+      }
     }
   }
 }

--- a/src/css/components/header.css
+++ b/src/css/components/header.css
@@ -149,3 +149,54 @@
     transform: translatex(0);
   }
 }
+
+.mobile-nav {
+  @media (--nav) { /* Should this wrap the entire mobile class? */
+    .site-header {
+      min-height: auto; /* auto? */
+
+      .nav-primary__icon {
+        display: none;
+      }
+    }
+
+    .site-branding {
+      grid-column: span 3;
+      padding: var(--sp);
+      background-image: linear-gradient(160deg, var(--color--blue-50) 0%, #0D7AB8 78.66%);
+      color: white;
+      font-size: 18px;
+      font-weight: bold;
+      box-shadow: calc(-1 * var(--sp)) 0 0 var(--color--blue-50);
+      /* Possibly redundant */
+      grid-column: span 4;
+      padding-top: var(--sp4);
+      font-size: 28px;
+
+      .site-branding__inner {
+        display: block;
+        height: auto; /* auto? */
+      }
+    }
+    .header-nav {
+      visibility: hidden;
+      position: fixed;
+      right: 0;
+      top: 0;
+      z-index: 5; /* appear above overlay */
+      transform: translatex(101%);
+      width: 100%;
+      height: 100%;
+      padding: 0 var(--sp) var(--sp);
+      overflow: auto;
+      max-width: 500px;
+      background-color: white;
+      border-top: solid white var(--sp3); /* Create room for the "close" button. */
+      transition: all 0.2s;
+      box-shadow: 0px 0px 72px rgba(0, 0, 0, 0.1);
+      /* Possibly redundant */
+      padding: 0 var(--sp3) var(--sp3);
+      border-top-width: var(--sp7);
+    }
+  }
+}


### PR DESCRIPTION
**Work in progress**. Manually adding mobile-nav class (could easily change the naming if necessary) to body will force hamburger menu at all breakpoints. Main thing that remains is ensuring that the contents on the slide out menu display with the correct styling. Right now only the search box displays. Hope to be able to finish this off in the next couple of days.