### PR TITLE
13476291: Create CSS body class that enables mobile menu at all widths

### DIFF
--- a/src/css/base/layout.css
+++ b/src/css/base/layout.css
@@ -5,8 +5,10 @@
   max-width: var(--max-width);
 
   @media (--nav) {
-    padding-left: var(--sp2);
-    padding-right: var(--sp2);
+    body:not(.is-always-mobile-nav) & {
+      padding-left: var(--sp2);
+      padding-right: var(--sp2);
+    }
   }
 }
 
@@ -29,13 +31,17 @@
 
 .content {
   @media (--nav) {
-    display: flex;
-    flex-direction: row-reverse;
+    body:not(.is-always-mobile-nav) & {
+      display: flex;
+      flex-direction: row-reverse;
+    }
   }
 }
 
 main {
   @media (--nav) {
-    margin-right: auto;
+    body:not(.is-always-mobile-nav) & {
+      margin-right: auto;
+    }
   }
 }

--- a/src/css/base/utility.css
+++ b/src/css/base/utility.css
@@ -23,11 +23,13 @@
   text-decoration: none;
 
   @media (--nav) {
-    margin-left: var(--content-left);
-    padding: var(--sp);
-    color: white;
-    font-size: 14px;
-    font-weight: bold;
+    body:not(.is-always-mobile-nav) & {
+      margin-left: var(--content-left);
+      padding: var(--sp);
+      color: white;
+      font-size: 14px;
+      font-weight: bold;
+    }
   }
 
   &:after {

--- a/src/css/components/embedded-media.css
+++ b/src/css/components/embedded-media.css
@@ -33,8 +33,10 @@ figcaption {
   }
 
   @media (--nav) {
-    width: calc(4 * var(--grid-col-width--nav) + 3 * var(--grid-gap--nav));
-    margin-right: calc(-3 * ((var(--grid-col-width--nav) + var(--grid-gap--nav))));
+    body:not(.is-always-mobile-nav) & {
+      width: calc(4 * var(--grid-col-width--nav) + 3 * var(--grid-gap--nav));
+      margin-right: calc(-3 * ((var(--grid-col-width--nav) + var(--grid-gap--nav))));
+    }
   }
 
   @media (--grid-max) {
@@ -61,8 +63,10 @@ figcaption {
   }
 
   @media (--nav) {
-    width: calc(4 * var(--grid-col-width--nav) + 3 * var(--grid-gap--nav));
-    margin-left: calc(-1 * ((var(--grid-col-width--nav) + var(--grid-gap--nav))));
+    body:not(.is-always-mobile-nav) & {
+      width: calc(4 * var(--grid-col-width--nav) + 3 * var(--grid-gap--nav));
+      margin-left: calc(-1 * ((var(--grid-col-width--nav) + var(--grid-gap--nav))));
+    }
   }
 
   @media (--grid-max) {

--- a/src/css/components/footer.css
+++ b/src/css/components/footer.css
@@ -3,7 +3,9 @@
   background: black;
 
   @media (--nav) {
-    padding-left: var(--content-left);
+    body:not(.is-always-mobile-nav) & {
+      padding-left: var(--content-left);
+    }
   }
 }
 
@@ -12,8 +14,10 @@
   background: linear-gradient(180deg, #0C0D0E 0%, #171E23 100%);
 
   @media (--nav) {
-    padding-top: var(--sp4);
-    padding-bottom: calc(13 * var(--sp));
+    body:not(.is-always-mobile-nav) & {
+      padding-top: var(--sp4);
+      padding-bottom: calc(13 * var(--sp));
+    }
   }
 }
 
@@ -25,7 +29,9 @@
   font-size: 14px;
 
   @media(--nav) {
-    grid-column-start: 3;
+    body:not(.is-always-mobile-nav) & {
+      grid-column-start: 3;
+    }
   }
 
   a {

--- a/src/css/components/header-buttons-mobile.css
+++ b/src/css/components/header-buttons-mobile.css
@@ -13,6 +13,8 @@
   }
 
   @media (--nav) {
-    display: none;
+    body:not(.is-always-mobile-nav) & {
+      display: none;
+    }
   }
 }

--- a/src/css/components/header-search-narrow.css
+++ b/src/css/components/header-search-narrow.css
@@ -11,7 +11,9 @@
   }
 
   @media (--nav) {
-    display: none;
+    body:not(.is-always-mobile-nav) & {
+      display: none;
+    }
   }
 
   form {

--- a/src/css/components/header-search-wide.css
+++ b/src/css/components/header-search-wide.css
@@ -22,7 +22,9 @@
   }
 
   @media (--nav) {
-    display: block;
+    body:not(.is-always-mobile-nav) & {
+      display: block;
+    }
   }
 
   form {
@@ -114,7 +116,9 @@
   cursor: pointer;
 
   @media (--nav) {
-    display: block;
+    body:not(.is-always-mobile-nav) & {
+      display: block;
+    }
   }
 
   &:focus {

--- a/src/css/components/header.css
+++ b/src/css/components/header.css
@@ -3,9 +3,11 @@
   position: relative;
 
   @media (--nav) {
-    /* Necessary to keep the content from jumping up when header transitions to fixed. */
-    min-height: var(--sp10);
-    border-bottom: solid 1px transparent; /* Will show in Windows high contrast mode. */
+    body:not(.is-always-mobile-nav) & {
+      /* Necessary to keep the content from jumping up when header transitions to fixed. */
+      min-height: var(--sp10);
+      border-bottom: solid 1px transparent; /* Will show in Windows high contrast mode. */
+    }
   }
 }
 
@@ -25,11 +27,13 @@
 
   &.js-fixed {
     @media (--nav) {
-      position: fixed;
-      z-index: 2; /* Appear above body content that is position: relative */
-      top: calc(-1 * var(--sp4));
-      width: 100%;
-      max-width: var(--max-bg-color);
+      body:not(.is-always-mobile-nav) & {
+        position: fixed;
+        z-index: 2; /* Appear above body content that is position: relative */
+        top: calc(-1 * var(--sp4));
+        width: 100%;
+        max-width: var(--max-bg-color);
+      }
     }
   }
 }
@@ -40,16 +44,20 @@
 
   .site-header__fixable.js-fixed & {
     @media (--nav) {
-      background: white;
-      box-shadow: -36px 1px 36px rgba(0, 0, 0, 0.08);
+      body:not(.is-always-mobile-nav) & {
+        background: white;
+        box-shadow: -36px 1px 36px rgba(0, 0, 0, 0.08);
+      }
     }
   }
 
   /* Hide the nav when it's fixed and not active. */
   .site-header__fixable.js-fixed &:not(.is-active) {
     @media (--nav) {
-      transform: translatex(-101%);
-      opacity: 0;
+      body:not(.is-always-mobile-nav) & {
+        transform: translatex(-101%);
+        opacity: 0;
+      }
     }
   }
 }
@@ -74,22 +82,24 @@
   }
 
   @media (--nav) {
-    grid-column: span 2;
-    width: calc(100% + 2 * var(--grid-gap--md));
-    margin-left: calc(-1 * var(--grid-gap--md));
-    margin-right: calc(-1 * var(--grid-gap--md));
-    padding-top: var(--sp4);
-    padding-left: var(--sp2);
-    padding-bottom: 0;
-    font-size: 32px;
-    line-height: var(--sp2);
-    letter-spacing: 0.02em;
-    box-shadow: calc(-1 * var(--content-left)) 0 0 var(--color--blue-50);
+    body:not(.is-always-mobile-nav) & {
+      grid-column: span 2;
+      width: calc(100% + 2 * var(--grid-gap--md));
+      margin-left: calc(-1 * var(--grid-gap--md));
+      margin-right: calc(-1 * var(--grid-gap--md));
+      padding-top: var(--sp4);
+      padding-left: var(--sp2);
+      padding-bottom: 0;
+      font-size: 32px;
+      line-height: var(--sp2);
+      letter-spacing: 0.02em;
+      box-shadow: calc(-1 * var(--content-left)) 0 0 var(--color--blue-50);
 
-    .site-branding__inner {
-      display: flex;
-      align-items: center;
-      height: var(--header-height-wide-when-fixed);
+      .site-branding__inner {
+        display: flex;
+        align-items: center;
+        height: var(--header-height-wide-when-fixed);
+      }
     }
   }
 
@@ -125,21 +135,23 @@
   }
 
   @media (--nav) {
-    visibility: visible;
-    position: static;
-    grid-column: 5 / 15;
-    height: var(--header-height-wide-when-fixed);
-    transform: none;
-    max-width: none;
-    padding: 0;
-    overflow: visible;
-    display: flex;
-    margin-top: auto;
-    align-items: center;
-    justify-content: flex-end;
-    border-top: 0;
-    transition: transform 0.2s;
-    box-shadow: none;
+    body:not(.is-always-mobile-nav) & {
+      visibility: visible;
+      position: static;
+      grid-column: 5 / 15;
+      height: var(--header-height-wide-when-fixed);
+      transform: none;
+      max-width: none;
+      padding: 0;
+      overflow: visible;
+      display: flex;
+      margin-top: auto;
+      align-items: center;
+      justify-content: flex-end;
+      border-top: 0;
+      transition: transform 0.2s;
+      box-shadow: none;
+    }
   }
 
   @media (--lg) {

--- a/src/css/components/main.css
+++ b/src/css/components/main.css
@@ -122,7 +122,9 @@ main {
     }
 
     @media (--nav) {
-      width: calc(10 * var(--grid-col-width--nav) + 9 * var(--grid-gap--nav));
+      body:not(.is-always-mobile-nav) & {
+        width: calc(10 * var(--grid-col-width--nav) + 9 * var(--grid-gap--nav));
+      }
     }
 
     @media (--grid-max) {
@@ -146,7 +148,9 @@ main {
       }
 
       @media (--nav) {
-        left: calc(-1 * (var(--grid-col-width--nav) + var(--grid-gap--nav)));
+        body:not(.is-always-mobile-nav) & {
+          left: calc(-1 * (var(--grid-col-width--nav) + var(--grid-gap--nav)));
+        }
       }
 
       @media (--grid-max) {
@@ -176,7 +180,9 @@ main {
       }
 
       @media (--nav) {
-        left: calc(-1 * (var(--grid-col-width--nav) + var(--grid-gap--nav)));
+        body:not(.is-always-mobile-nav) & {
+          left: calc(-1 * (var(--grid-col-width--nav) + var(--grid-gap--nav)));
+        }
       }
 
       @media (--grid-max) {

--- a/src/css/components/nav-button-wide.css
+++ b/src/css/components/nav-button-wide.css
@@ -4,24 +4,26 @@
   display: none;
 
   @media (--nav) {
-    visibility: hidden;
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-    width: var(--content-left);
-    height: calc(6 * var(--sp));
-    border: 0;
-    cursor: pointer;
-    background-color: var(--color--blue-50);
-    outline: 0;
+    body:not(.is-always-mobile-nav) & {
+      visibility: hidden;
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      width: var(--content-left);
+      height: calc(6 * var(--sp));
+      border: 0;
+      cursor: pointer;
+      background-color: var(--color--blue-50);
+      outline: 0;
 
-    &:focus {
-      border: solid 1px transparent; /* Will show in IE/Edge high contrast mode. */
-    }
+      &:focus {
+        border: solid 1px transparent; /* Will show in IE/Edge high contrast mode. */
+      }
 
-    .js-fixed & {
-      visibility: visible;
+      .js-fixed & {
+        visibility: visible;
+      }
     }
   }
 }

--- a/src/css/components/nav-primary.css
+++ b/src/css/components/nav-primary.css
@@ -16,7 +16,9 @@
       justify-content: space-between;
 
       @media (--nav) {
-        flex-wrap: nowrap; /* Ensure that subnav toggle button doesn't wrap underneath link. */
+        body:not(.is-always-mobile-nav) & {
+          flex-wrap: nowrap; /* Ensure that subnav toggle button doesn't wrap underneath link. */
+        }
       }
     }
   }
@@ -30,8 +32,10 @@
     text-decoration: none;
 
     @media (--nav) {
-      font-size: 16px;
-      letter-spacing: 0.02em;
+      body:not(.is-always-mobile-nav) & {
+        font-size: 16px;
+        letter-spacing: 0.02em;
+      }
     }
   }
 }
@@ -41,69 +45,71 @@
   padding: 0;
 
   @media (--nav) {
-    display: flex;
-    align-items: center;
-
-    > li {
-      position: relative; /* Anchor secondary menu */
+    body:not(.is-always-mobile-nav) & {
       display: flex;
       align-items: center;
-      margin: 0;
 
-      &:not(:last-child) {
-        margin-right: var(--sp2);
-      }
-
-      html:not(.js) &:hover {
-        .primary-nav--level-2 {
-          visibility: visible;
-          opacity: 1;
-          transform: translate(-50%, 0);
-        }
-      }
-
-      /*
-        Cannot combine the focus-within pseudoselector with other selectors,
-        because it will break IE11 and MS Edge.
-      */
-       html:not(.js) &:focus-within {
-        .primary-nav--level-2 {
-          visibility: visible;
-          opacity: 1;
-          transform: translate(-50%, 0);
-        }
-      }
-    }
-
-    a {
-      position: relative;
-      display: flex;
-
-      &:hover,
-      &:focus {
-        outline: 0;
-
-        span:after {
-          transform: scalex(1);
-        }
-      }
-
-      span {
-        position: relative;
-        display: inline-flex;
+      > li {
+        position: relative; /* Anchor secondary menu */
+        display: flex;
         align-items: center;
-        padding: var(--sp2) 0;
+        margin: 0;
 
-        &:after {
-          content: '';
-          position: absolute;
-          left: 0;
-          bottom: 0;
-          width: 100%;
-          height: 0;
-          transform: scalex(0);
-          border-top: solid var(--sp0-5) var(--color--blue-50);
-          transition: transform 0.2s;
+        &:not(:last-child) {
+          margin-right: var(--sp2);
+        }
+
+        html:not(.js) &:hover {
+          .primary-nav--level-2 {
+            visibility: visible;
+            opacity: 1;
+            transform: translate(-50%, 0);
+          }
+        }
+
+        /*
+          Cannot combine the focus-within pseudoselector with other selectors,
+          because it will break IE11 and MS Edge.
+        */
+        html:not(.js) &:focus-within {
+          .primary-nav--level-2 {
+            visibility: visible;
+            opacity: 1;
+            transform: translate(-50%, 0);
+          }
+        }
+      }
+
+      a {
+        position: relative;
+        display: flex;
+
+        &:hover,
+        &:focus {
+          outline: 0;
+
+          span:after {
+            transform: scalex(1);
+          }
+        }
+
+        span {
+          position: relative;
+          display: inline-flex;
+          align-items: center;
+          padding: var(--sp2) 0;
+
+          &:after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 0;
+            transform: scalex(0);
+            border-top: solid var(--sp0-5) var(--color--blue-50);
+            transition: transform 0.2s;
+          }
         }
       }
     }
@@ -127,46 +133,48 @@
   }
 
   @media (--nav) {
-    position: absolute;
-    z-index: 5; /* Appear above search container. */
-    top: calc(100% - (0.5 * var(--sp)));
-    left: 50%;
-    transform: translate(-50%, -20px);
-    visibility: hidden;
-    padding: calc(3 * var(--sp)) var(--sp2);
-    background: white;
-    border-top: solid var(--color--blue-50) var(--sp0-5);
-    border-right: solid 1px transparent; /* Transparent borders useful for Windows High Contrast mode. */
-    border-bottom: solid 1px transparent;
-    border-left: solid 1px transparent;
-    margin-top: 0;
-    margin-left: 0;
-    border-radius: 0px 0px 2px 2px;
-    width: 250px;
-    box-shadow: 0 1px 36px rgba(0, 0, 0, 0.08);
-    opacity: 0;
-    transition: all 0.2s;
-    max-height: none;
-    overflow: visible;
-
-    /* Arrow */
-    &:after {
-      content: '';
+    body:not(.is-always-mobile-nav) & {
       position: absolute;
-      bottom: calc(100% + (0.5 * var(--sp)));
+      z-index: 5; /* Appear above search container. */
+      top: calc(100% - (0.5 * var(--sp)));
       left: 50%;
-      transform: translatex(-50%);
-      height: 0;
-      width: 0;
-      border-left: solid 10px transparent;
-      border-right: solid 10px transparent;
-      border-bottom: solid 10px var(--color--blue-50);
-    }
+      transform: translate(-50%, -20px);
+      visibility: hidden;
+      padding: calc(3 * var(--sp)) var(--sp2);
+      background: white;
+      border-top: solid var(--color--blue-50) var(--sp0-5);
+      border-right: solid 1px transparent; /* Transparent borders useful for Windows High Contrast mode. */
+      border-bottom: solid 1px transparent;
+      border-left: solid 1px transparent;
+      margin-top: 0;
+      margin-left: 0;
+      border-radius: 0px 0px 2px 2px;
+      width: 250px;
+      box-shadow: 0 1px 36px rgba(0, 0, 0, 0.08);
+      opacity: 0;
+      transition: all 0.2s;
+      max-height: none;
+      overflow: visible;
 
-    &.is-active {
-      visibility: visible;
-      opacity: 1;
-      transform: translate(-50%, 0);
+      /* Arrow */
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: calc(100% + (0.5 * var(--sp)));
+        left: 50%;
+        transform: translatex(-50%);
+        height: 0;
+        width: 0;
+        border-left: solid 10px transparent;
+        border-right: solid 10px transparent;
+        border-bottom: solid 10px var(--color--blue-50);
+      }
+
+      &.is-active {
+        visibility: visible;
+        opacity: 1;
+        transform: translate(-50%, 0);
+      }
     }
   }
 
@@ -180,7 +188,9 @@
     opacity: 1;
 
     @media (--nav) {
-      margin-top: 0;
+      body:not(.is-always-mobile-nav) & {
+        margin-top: 0;
+      }
     }
   }
 
@@ -190,7 +200,9 @@
     opacity: 1;
 
     @media (--nav) {
-      margin-top: 0;
+      body:not(.is-always-mobile-nav) & {
+        margin-top: 0;
+      }
     }
   }
 
@@ -200,14 +212,16 @@
     font-weight: normal;
 
     @media (--nav) {
-      display: block;
+      body:not(.is-always-mobile-nav) & {
+        display: block;
 
-      span {
-        padding: var(--sp0-5) 0;
+        span {
+          padding: var(--sp0-5) 0;
 
-        &:after {
-          border-top-width: 3px;
-          transform-origin: left;
+          &:after {
+            border-top-width: 3px;
+            transform-origin: left;
+          }
         }
       }
     }
@@ -229,24 +243,26 @@
   cursor: pointer;
 
   @media (--nav) {
-    align-self: stretch;
-    width: calc(var(--sp2) + 8px);
-    height: auto;
-    margin-right: calc(-1 * var(--sp2));
-    padding: 0;
+    body:not(.is-always-mobile-nav) & {
+      align-self: stretch;
+      width: calc(var(--sp2) + 8px);
+      height: auto;
+      margin-right: calc(-1 * var(--sp2));
+      padding: 0;
 
-    &:focus {
-      outline: 0;
+      &:focus {
+        outline: 0;
 
-      /*
-        Add a transparent border and adjust width for Windows High Contrast mode,
-        where transparent borders become visible.
-      */
-      border: solid 1px transparent;
+        /*
+          Add a transparent border and adjust width for Windows High Contrast mode,
+          where transparent borders become visible.
+        */
+        border: solid 1px transparent;
 
-      &:after {
-        border-color: var(--color--blue-50);
-        left: 7px; /* Account for the 1px transparent border that gets added to the button at focus. */
+        &:after {
+          border-color: var(--color--blue-50);
+          left: 7px; /* Account for the 1px transparent border that gets added to the button at focus. */
+        }
       }
     }
   }
@@ -263,7 +279,9 @@
     background: var(--color--blue-50);
 
     @media (--nav) {
-      content: none;
+      body:not(.is-always-mobile-nav) & {
+        content: none;
+      }
     }
   }
 
@@ -272,16 +290,18 @@
     transition: opacity 0.2s;
 
     @media (--nav) {
-      content: '';
-      top: calc(50% - 2px);
-      left: 8px;
-      height: 8px;
-      width: 8px;
-      border-right: solid 2px currentColor;
-      border-bottom: solid 2px currentColor;
-      transform: translatey(-50%) rotate(45deg);
-      background: transparent;
-      opacity: 0.8;
+      body:not(.is-always-mobile-nav) & {
+        content: '';
+        top: calc(50% - 2px);
+        left: 8px;
+        height: 8px;
+        width: 8px;
+        border-right: solid 2px currentColor;
+        border-bottom: solid 2px currentColor;
+        transform: translatey(-50%) rotate(45deg);
+        background: transparent;
+        opacity: 0.8;
+      }
     }
   }
 
@@ -290,7 +310,9 @@
       opacity: 0;
 
       @media (--nav) {
-        opacity: 0.8;
+        body:not(.is-always-mobile-nav) & {
+          opacity: 0.8;
+        }
       }
     }
   }

--- a/src/css/components/nav-secondary.css
+++ b/src/css/components/nav-secondary.css
@@ -3,8 +3,10 @@
   margin: var(--sp2) 0;
 
   @media (--nav) {
-    justify-content: flex-end;
-    margin: 0;
+    body:not(.is-always-mobile-nav) & {
+      justify-content: flex-end;
+      margin: 0;
+    }
   }
 }
 
@@ -14,20 +16,22 @@
   font-size: 14px;
 
   @media (--nav) {
-    position: relative;
-    display: flex;
-    margin-left: var(--sp0-5);
-    padding-left: var(--sp2);
+    body:not(.is-always-mobile-nav) & {
+      position: relative;
+      display: flex;
+      margin-left: var(--sp0-5);
+      padding-left: var(--sp2);
 
-    &:before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 50%;
-      transform: translatey(-50%);
-      height: var(--sp2);
-      width: 2px;
-      background-color: var(--color--gray-70);
+      &:before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 50%;
+        transform: translatey(-50%);
+        height: var(--sp2);
+        width: 2px;
+        background-color: var(--color--gray-70);
+      }
     }
   }
 
@@ -43,7 +47,9 @@
     margin-right: var(--sp1-5);
 
     @media (--nav) {
-      margin-right: var(--sp2);
+      body:not(.is-always-mobile-nav) & {
+        margin-right: var(--sp2);
+      }
     }
   }
 

--- a/src/css/components/social-container.css
+++ b/src/css/components/social-container.css
@@ -1,8 +1,10 @@
 .social-container {
   @media (--nav) {
-    width: var(--content-left);
-    flex-shrink: 0;
-    background-color: var(--color--gray-95);
+    body:not(.is-always-mobile-nav) & {
+      width: var(--content-left);
+      flex-shrink: 0;
+      background-color: var(--color--gray-95);
+    }
   }
 }
 
@@ -12,16 +14,18 @@
   justify-content: flex-end;
 
   @media (--nav) {
-    writing-mode: vertical-rl;
-    transform: rotate(180deg);
-    width: var(--content-left);
-    text-align: right; /* IE11 */
+    body:not(.is-always-mobile-nav) & {
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      width: var(--content-left);
+      text-align: right; /* IE11 */
 
-    img {
-      margin: 10px 5px 10px 10px; /* IE11 */
+      img {
+        margin: 10px 5px 10px 10px; /* IE11 */
 
-      @supports (display: block) { /* Override IE11 values. */
-        margin: 10px;
+        @supports (display: block) { /* Override IE11 values. */
+          margin: 10px;
+        }
       }
     }
   }
@@ -39,15 +43,17 @@
   background-color: var(--color--gray-95);
 
   @media (--nav) {
-    position: relative;
-    width: var(--content-left);
-    padding: calc(9 * var(--sp)) 0;
+    body:not(.is-always-mobile-nav) & {
+      position: relative;
+      width: var(--content-left);
+      padding: calc(9 * var(--sp)) 0;
 
-    &.js-fixed {
-      position: fixed;
-      top: var(--sp6);
-      left: 0;
-      height: calc(100vh - 6 * var(--sp))
+      &.js-fixed {
+        position: fixed;
+        top: var(--sp6);
+        left: 0;
+        height: calc(100vh - 6 * var(--sp))
+      }
     }
   }
 }

--- a/src/css/components/table.css
+++ b/src/css/components/table.css
@@ -75,7 +75,9 @@ table {
   }
 
   @media (--nav) {
-    width: calc(10 * var(--grid-col-width--nav) + 9 * var(--grid-gap--nav));
+    body:not(.is-always-mobile-nav) & {
+      width: calc(10 * var(--grid-col-width--nav) + 9 * var(--grid-gap--nav));
+    }
   }
 
   @media (--grid-max) {


### PR DESCRIPTION
Forces mobile nav when is-always-mobile-nav class (I'll need to update the patch on https://www.drupal.org/project/olivero/issues/3115429 to use that adjusted class name) is added to body.

Now that this is fully functioning, one thing we might want to address is the placement of the menu close button on wide device widths. I'd expect it to be inside the menu, but it stays stationary.  Could take a shot at adjusting that if it helps.

![Screenshot at Feb 28 14-19-30](https://user-images.githubusercontent.com/889478/75584707-f184cc00-5a35-11ea-9ebd-f25dbb5d8972.png)
