### PR TITLE
3117128: menu button alignment

### DIFF
--- a/src/css/components/header-buttons-mobile.css
+++ b/src/css/components/header-buttons-mobile.css
@@ -18,3 +18,14 @@
     }
   }
 }
+
+.is-always-mobile-nav {
+  .mobile-nav-button[aria-expanded="true"] {
+    @media (--grid-max) {
+      position: fixed;
+      top: var(--sp4);
+      right: var(--sp);
+      z-index: 10;
+    }
+  }
+}


### PR DESCRIPTION
When is-always-mobile-nav is enabled at device widths larger than --grid-max the menu close button is not in the slide out menu drawer when expanded. This PR re-locates it to the upper right corner of the drawer.